### PR TITLE
Scheduling users for deactivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .clasp.json
 utils/sheets.json
+utils/prod.json
 node_modules
 .env
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # user manager
 
-Those scripts combine Google Forms, Sheets, Gmail and Admin panel together, to enable user creation 
+Those scripts combine Google Forms, Sheets, Gmail and Admin panel together, to enable user creation
 automatization. User registers using Forms, the data is passed to Sheets and mail is being
-sent to the superior (passed in form field). After the supierior confirms the validity of request, the 
+sent to the superior (passed in form field). After the supierior confirms the validity of request, the
 admin is notified via email and can click to approve new user creation request.
 
 ## Build
@@ -26,5 +26,7 @@ cd build
 ../utils/updateSheets.sh ../utils/sheets.json
 ```
 
-What's in the `sheets.json`? You need to pass id to the compliant Google Sheet document. 
+What's in the `sheets.json`? You need to pass id to the compliant Google Sheet document.
 Send mail request for template at: patryk.niedzwiedzinski at zhr.pl
+
+! After running the script go to the Google App Script > Deploy > Manage deployments > Edit > New version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-manager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "User manager of Google Workspace using Google App Script",
   "main": "index.js",
   "scripts": {

--- a/src/handlers/deactivationHandler.ts
+++ b/src/handlers/deactivationHandler.ts
@@ -1,0 +1,199 @@
+import { sendEmail } from "../lib/utils";
+import { NONLEADERS_GROUP, PROXY_URL } from "../config";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DEACTIVATION_OFFSET_MS = 29 * 24 * 60 * 60 * 1000; // 4 weeks from now (4*7+1 = 29)
+
+/**
+ * Worker function that checks if user should be deactivated
+ */
+export function oldCleanup(): void {
+  if (!AdminDirectory || !AdminDirectory.Users) {
+    throw new Error("AdminDirectory.Users is undefined");
+  }
+  let page: GoogleAppsScript.AdminDirectory.Schema.Users;
+  let pageToken: string | undefined;
+
+  do {
+    // Get users from NONLEADERS_GROUP
+    page = AdminDirectory.Users.list({
+      domain: "zhr.pl",
+      query: `orgUnitPath='${NONLEADERS_GROUP}' isSuspended=false`, // only active users
+      projection: "full", // Needed for custom schemas and creationTime
+      maxResults: 100,
+      pageToken: pageToken,
+    });
+
+    const users = page.users || [];
+
+    for (let user of users) {
+      const deadlineString = getRelation(
+        user.relations,
+        "scheduled_for_deactivation"
+      );
+
+      if (deadlineString) {
+        const deadline = new Date(deadlineString);
+        const timeDiff = deadline.getTime() - new Date().getTime();
+
+        const daysLeft = Math.ceil(timeDiff / MS_PER_DAY);
+
+        Logger.log(
+          `Do dezaktywacji użytkownika ${user.primaryEmail} pozostało dni: ${daysLeft}`
+        );
+
+        if (daysLeft <= 0) {
+          try {
+            // TODO
+            //AdminDirectory.Users!.patch({ suspended: true }, user.id!);
+            // TODO - Notify for deactivation
+
+            Logger.log(
+              `[DEACTIVATED] User ${user.primaryEmail} has been suspended.`
+            );
+          } catch (e) {
+            Logger.log(`[ERROR] Failed to suspend ${user.primaryEmail}: ${e}`);
+          }
+        }
+      }
+    }
+  } while (pageToken);
+}
+
+/**
+ * Yearly cleanup of users who left the organization
+ * During the cleanup process, all users in NONLEADERS_GROUP that were confirmed more than 2 years ago
+ * will be asked for reconfirmation from their superior. If no confirmation is received within 30 days,
+ * the account will be deactivated.
+ *
+ * 1. Query all users in NONLEADERS_GROUP that are not suspended
+ * 2. Filter only users that:
+ *      - have relation of type "confirmation_date" and with value date older than 2 years
+ *      - if no relation present, check if user was created more than 2 years ago
+ * 3. Check if they have empty (or not present) "scheduled_for_deactivation" relation (meaning not scheduled yet)
+ * 4. Empty the superior relation
+ * 5. Set the "scheduled_for_deactivation" relation to DEACTIVATION_OFFSET
+ * 6. Notify the user
+ */
+export function scheduleForDeactivation(): void {
+  if (!AdminDirectory || !AdminDirectory.Users) {
+    throw new Error("AdminDirectory.Users is undefined");
+  }
+
+  const TWO_YEARS_MS = 2 * 365 * 24 * 60 * 60 * 1000;
+  const now = new Date();
+
+  let page: GoogleAppsScript.AdminDirectory.Schema.Users;
+  let pageToken: string | undefined;
+
+  do {
+    // Get users from NONLEADERS_GROUP
+    page = AdminDirectory.Users.list({
+      domain: "zhr.pl",
+      query: `orgUnitPath='${NONLEADERS_GROUP}' isSuspended=false`, // only active users
+      projection: "full", // Needed for custom schemas and creationTime
+      maxResults: 100,
+      pageToken: pageToken,
+    });
+
+    const users = page.users;
+
+    const usersForReconfirmation =
+      users?.filter((user: GoogleAppsScript.AdminDirectory.Schema.User) => {
+        const customConfirmation = user.relations
+          ? getRelation(user.relations, "confirmation_date")
+          : null;
+
+        // Use creationTime if confirmation_date is not present
+        const confirmationDate = customConfirmation || user.creationTime;
+
+        if (!confirmationDate) return false; // API error
+
+        const timeSinceCreation =
+          now.getTime() - new Date(confirmationDate).getTime();
+        return timeSinceCreation > TWO_YEARS_MS;
+      }) || [];
+
+    for (const user of usersForReconfirmation) {
+      if (!user.id || !user.primaryEmail) {
+        Logger.log(`Skipping user due to missing id: ${JSON.stringify(user)}`);
+        continue;
+      }
+
+      // Check if account was already scheduled for deactivation
+      const warningRelation = getRelation(
+        user.relations,
+        "scheduled_for_deactivation"
+      );
+      if (warningRelation) {
+        // Account already scheduled for deactivation
+        continue;
+      }
+
+      const deadline = new Date(now.getTime() + DEACTIVATION_OFFSET_MS);
+
+      // Prepare Payload: Copy existing relations to avoid overwriting them
+      const currentRelations = user.relations || [];
+      const newRelations = [
+        ...currentRelations,
+        {
+          type: "custom",
+          customType: "scheduled_for_deactivation",
+          value: deadline.toISOString(),
+        },
+      ];
+
+      try {
+        // Use PATCH to only update the relations field
+        AdminDirectory.Users.patch({ relations: newRelations }, user.id);
+
+        //notifyForDeactivation(user, 30);
+
+        Logger.log(
+          `[SCHEDULED] User ${
+            user.primaryEmail
+          } marked for deactivation on ${deadline.toISOString()}`
+        );
+      } catch (error) {
+        Logger.log(`[ERROR] Failed to schedule ${user.primaryEmail}: ${error}`);
+      }
+    }
+
+    pageToken = page.nextPageToken;
+  } while (pageToken);
+}
+
+function notifyForDeactivation(
+  user: GoogleAppsScript.AdminDirectory.Schema.User,
+  days: number
+): void {
+  if (!user.primaryEmail) {
+    Logger.log(`Skipping user due to missing email: ${JSON.stringify(user)}`);
+    return;
+  }
+  const deactivationNoticeTemplate =
+    HtmlService.createTemplateFromFile("deactivationNotice");
+  deactivationNoticeTemplate.mail = user.primaryEmail;
+  deactivationNoticeTemplate.days = days === 1 ? "1 dzień" : `${days} dni`;
+  deactivationNoticeTemplate.verificationLink = `${PROXY_URL}/confirm-zhr.html?id=${user.id}&scope=directory`;
+
+  sendEmail(
+    [user.primaryEmail, user.recoveryEmail].join(","),
+    `[WYMAGANA AKCJA] Weryfikacja konta ${user.primaryEmail}`,
+    "",
+    {
+      htmlBody: deactivationNoticeTemplate.evaluate().getContent(),
+    }
+  );
+}
+
+function getRelation(
+  relations: object[] | undefined,
+  key: string
+): string | undefined {
+  const relation = relations?.find(
+    (r: GoogleAppsScript.AdminDirectory.Schema.UserRelation) =>
+      r.customType === key
+  ) as GoogleAppsScript.AdminDirectory.Schema.UserRelation | undefined;
+  return relation?.value;
+}

--- a/src/handlers/deactivationHandler.ts
+++ b/src/handlers/deactivationHandler.ts
@@ -80,11 +80,13 @@ export function oldCleanup(): void {
     pageToken = page.nextPageToken;
   } while (pageToken);
 
-  sendEmail(
-    ADMIN_MAIL,
-    "oldCleanup: deaktywacje wykonane",
-    deactivatedUsers.join(" \n")
-  );
+  if (deactivatedUsers.length) {
+    sendEmail(
+      ADMIN_MAIL,
+      "oldCleanup: deaktywacje wykonane",
+      deactivatedUsers.join(" \n")
+    );
+  }
 }
 
 /**
@@ -165,11 +167,13 @@ export function scheduleForDeactivation(): void {
     pageToken = page.nextPageToken;
   } while (pageToken);
 
-  sendEmail(
-    ADMIN_MAIL,
-    "scheduleForDeactivation: użytkownicy zaplanowani do dezaktywacji",
-    scheduledUsers.join(" \n")
-  );
+  if (scheduledUsers.length) {
+    sendEmail(
+      ADMIN_MAIL,
+      "scheduleForDeactivation: użytkownicy zaplanowani do dezaktywacji",
+      scheduledUsers.join(" \n")
+    );
+  }
 }
 
 function notifyForDeactivation(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,10 @@ import { doPost } from "./handlers/httpHandler";
 import { onEdit } from "./handlers/editHandler";
 import { freshCleanup } from "./handlers/cleanupHandler";
 import { onOpen, groupUpdateHandler } from "./handlers/groupUpdateHandler";
+import {
+  oldCleanup,
+  scheduleForDeactivation,
+} from "./handlers/deactivationHandler";
 
 export {
   // send emails after form submit
@@ -16,4 +20,8 @@ export {
   // Google Sheets onOpen handler - update leaders group
   onOpen,
   groupUpdateHandler,
+  // CRON job - remove users scheduled for deactivation
+  oldCleanup,
+  // CRON job - schedule users for deactivation
+  scheduleForDeactivation,
 };

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -63,6 +63,16 @@ export function getGoogleUser(
   }
 }
 
+export function getGoogleUserSafe(
+  email: string
+): GoogleAppsScript.AdminDirectory.Schema.User | null {
+  try {
+    return getGoogleUser(email);
+  } catch (e) {
+    return null;
+  }
+}
+
 function userExists(mail: string) {
   try {
     if (AdminDirectory && AdminDirectory.Users) {

--- a/src/templates/deactivationCancelled.html
+++ b/src/templates/deactivationCancelled.html
@@ -59,7 +59,6 @@
       <div class="content">
         <p>
           Twoje konto @zhr.pl zostało potwierdzone i nie zostanie wyłączone.
-          Przy innym ogniu w inną noc...
         </p>
         <p></p>
       </div>

--- a/src/templates/deactivationCancelled.html
+++ b/src/templates/deactivationCancelled.html
@@ -52,7 +52,7 @@
       <div class="header">
         <h1>
           Konto
-          <?= mail ?>
+          <a href="mailto:<?= mail ?>" style="color: #fff"><?= mail ?></a>
           zostało potwierdzone
         </h1>
       </div>

--- a/src/templates/deactivationCancelled.html
+++ b/src/templates/deactivationCancelled.html
@@ -50,13 +50,16 @@
   <body>
     <div class="container">
       <div class="header">
-        <h1>Sukces!</h1>
+        <h1>
+          Konto
+          <?= mail ?>
+          zostało potwierdzone
+        </h1>
       </div>
       <div class="content">
         <p>
-          Konto
-          <?= mail ?>
-          zostało potwierdzone.
+          Twoje konto @zhr.pl zostało potwierdzone i nie zostanie wyłączone.
+          Przy innym ogniu w inną noc...
         </p>
         <p></p>
       </div>

--- a/src/templates/deactivationNotice.html
+++ b/src/templates/deactivationNotice.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>[WYMAGANA AKCJA] Weryfikacja konta <?= mail ?></title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: "Roboto Slab", sans-serif;
+        background-color: #fff; /* --bg-primary */
+        color: #000; /* --primary */
+      }
+      .container {
+        max-width: 600px;
+        margin: auto;
+        background: white;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.25);
+        overflow: hidden;
+      }
+      .header {
+        background-color: #507b34; /* --bg-secondary */
+        color: #fff; /* --secondary */
+        padding: 20px;
+        text-align: center;
+      }
+      .content {
+        padding: 20px;
+        text-align: center;
+      }
+      .button {
+        display: inline-block;
+        padding: 10px 20px;
+        font-size: 16px;
+        color: #fff;
+        background-color: #507b34; /* --bg-secondary */
+        text-decoration: none;
+        border-radius: 5px;
+        margin: 15px;
+      }
+      .footer {
+        text-align: center;
+        font-size: 12px;
+        color: #888;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>
+          Weryfikacja Twojego konta
+          <a href="mailto:<?= mail ?>" style="color: #fff"><?= mail ?></a>
+        </h1>
+      </div>
+      <div class="content">
+        <h2>Czuwaj!</h2>
+        <p>
+          <em>
+            "W owym czasie wyszło rozporządzenie Cezara Augusta, żeby
+            przeprowadzić spis ludności w całym państwie."
+          </em>
+          <br />
+          ~ Łk 2,1
+        </p>
+        <p></p>
+        <p>
+          W ramach corocznego spisu weryfikujemy konta mailowe w domenie zhr.pl.
+          Odzywamy się do Ciebie, żeby sprawdzić, czy nadal potrzebujesz dostępu
+          do konta
+          <strong><?= mail ?></strong>.
+        </p>
+        <p></p>
+        <p>
+          Jeżeli jesteś aktywnym członkiem ZHR, przekaż ten mail do swojego
+          przełożonego (musi to być instruktor), aby kliknął poniższy przycisk i
+          potwierdził aktywność Twojego konta:
+        </p>
+        <a href="<?= verificationLink ?>" class="button" style="color: #fff"
+          >Potwierdzam!</a
+        >
+        <hr />
+        <p>
+          ❗Na potwierdzenie konta masz
+          <?= days ?>. Po tym czasie konto zostanie dezaktywowane.❗
+        </p>
+        <p>
+          Jeśli uważasz że coś się nie zgadza, pisz śmiało na admin.wlkp@zhr.pl
+        </p>
+      </div>
+      <div class="footer">
+        <p>Zespół IT ZHR Okręg Wielkopolski</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/templates/deactivationNotice.html
+++ b/src/templates/deactivationNotice.html
@@ -58,15 +58,6 @@
       <div class="content">
         <h2>Czuwaj!</h2>
         <p>
-          <em>
-            "W owym czasie wyszło rozporządzenie Cezara Augusta, żeby
-            przeprowadzić spis ludności w całym państwie."
-          </em>
-          <br />
-          ~ Łk 2,1
-        </p>
-        <p></p>
-        <p>
           W ramach corocznego spisu weryfikujemy konta mailowe w domenie zhr.pl.
           Odzywamy się do Ciebie, żeby sprawdzić, czy nadal potrzebujesz dostępu
           do konta
@@ -84,10 +75,11 @@
         <hr />
         <p>
           ❗Na potwierdzenie konta masz
-          <?= days ?>. Po tym czasie konto zostanie dezaktywowane.❗
+          <?= days ?>. Po tym czasie konto zostanie wyłączone.❗
         </p>
         <p>
           Jeśli uważasz że coś się nie zgadza, pisz śmiało na admin.wlkp@zhr.pl
+          (po prostu odpowiedz na tego maila).
         </p>
       </div>
       <div class="footer">

--- a/src/templates/deactivationPerformed.html
+++ b/src/templates/deactivationPerformed.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Konto <?= mail ?> zostało wyłączone</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: "Roboto Slab", sans-serif;
+        background-color: #fff; /* --bg-primary */
+        color: #000; /* --primary */
+      }
+      .container {
+        max-width: 600px;
+        margin: auto;
+        background: white;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.25);
+        overflow: hidden;
+      }
+      .header {
+        background-color: #507b34; /* --bg-secondary */
+        color: #fff; /* --secondary */
+        padding: 20px;
+        text-align: center;
+      }
+      .content {
+        padding: 20px;
+        text-align: center;
+      }
+      .button {
+        display: inline-block;
+        padding: 10px 20px;
+        font-size: 16px;
+        color: #fff;
+        background-color: #507b34; /* --bg-secondary */
+        text-decoration: none;
+        border-radius: 5px;
+        margin: 15px;
+      }
+      .footer {
+        text-align: center;
+        font-size: 12px;
+        color: #888;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>
+          Konto
+          <?= mail ?>
+          zostało wyłączone
+        </h1>
+      </div>
+      <div class="content">
+        <p>
+          Nie dostaliśmy potwierdzenia od Twojego przełożonego, dlatego Twoje
+          konto @zhr.pl zostało wyłączone. Jeśli uważasz, że to pomyłka,
+          skontaktuj się z nami pod adresem
+          <a href="mailto:admin.wlkp@zhr.pl">admin.wlkp@zhr.pl</a>
+        </p>
+        <p></p>
+      </div>
+
+      <div class="footer">
+        <p>Zespół IT ZHR Okręg Wielkopolski</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/templates/deactivationPerformed.html
+++ b/src/templates/deactivationPerformed.html
@@ -61,7 +61,8 @@
           Nie dostaliśmy potwierdzenia od Twojego przełożonego, dlatego Twoje
           konto @zhr.pl zostało wyłączone. Jeśli uważasz, że to pomyłka,
           skontaktuj się z nami pod adresem
-          <a href="mailto:admin.wlkp@zhr.pl">admin.wlkp@zhr.pl</a>
+          <a href="mailto:admin.wlkp@zhr.pl">admin.wlkp@zhr.pl</a> (po prostu
+          odpowiedz na tego maila).
         </p>
         <p></p>
       </div>

--- a/src/templates/deactivationPerformed.html
+++ b/src/templates/deactivationPerformed.html
@@ -52,7 +52,7 @@
       <div class="header">
         <h1>
           Konto
-          <?= mail ?>
+          <a href="mailto:<?= mail ?>" style="color: #fff"><?= mail ?></a>
           zostało wyłączone
         </h1>
       </div>


### PR DESCRIPTION
This change uses user relations (https://developers.google.com/workspace/admin/directory/reference/rest/v1/users#User.FIELDS.relations) to schedule user for deactivation. With `scheduleUserForDeactivation` I assign user date of deactivation and the `oldCleanup` function (which runs everyday) check if account should be suspended. For dates 14-day-before, 7-days-before and 1-day-before `oldCleanup` will send a notification to primary and recovery emails to alert user of deactivation. Deactivation can be terminated when account is confirmed (using the same logic as before).