### PR TITLE
chore: add error handling for getGoogleUser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-manager",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-manager",
-      "version": "1.2.0",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "jsrsasign": "^11.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5098,9 +5098,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-manager",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "description": "User manager of Google Workspace using Google App Script",
   "main": "index.js",
   "scripts": {

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -53,11 +53,11 @@ export function getGoogleUser(
   mail: string
 ): GoogleAppsScript.AdminDirectory.Schema.User {
   if (AdminDirectory && AdminDirectory.Users) {
-    const user = AdminDirectory.Users.get(mail);
-    if (!user) {
-      throw new Error("Coulnd't fetch google user");
+    try {
+      return AdminDirectory.Users.get(mail);
+    } catch (e) {
+      throw new Error(`Coulnd't fetch google user ${mail}: ${e}`);
     }
-    return user;
   } else {
     throw new Error("AdminDirectory.Users is undefined");
   }


### PR DESCRIPTION
When freshCleanup runs on data out-of-sync with Google Directory, it will try to get user from Google API that might not exist. This change wraps getGoogleUser with context logging for finding out-of-sync user