### PR TITLE
Fix cleanup job crash due to rate limits and add error reporting

### DIFF
--- a/src/handlers/deactivationHandler.ts
+++ b/src/handlers/deactivationHandler.ts
@@ -151,7 +151,6 @@ export function scheduleForDeactivation(): void {
 
   let page: GoogleAppsScript.AdminDirectory.Schema.Users;
   let pageToken: string | undefined;
-  const scheduledUsers: string[] = [];
   const failedUsers: string[] = [];
   const notifiedUsers: { email: string; deadline: string }[] = [];
 
@@ -206,7 +205,6 @@ export function scheduleForDeactivation(): void {
           scheduleUserForDeactivation(user, deadline);
           notifyForDeactivation(user, deadline);
           Utilities.sleep(2000); // Wait 2s to avoid hitting rate limits
-          scheduledUsers.push(user.primaryEmail);
           notifiedUsers.push({
             email: user.primaryEmail,
             deadline: deadline.toISOString(),
@@ -233,13 +231,8 @@ export function scheduleForDeactivation(): void {
   }
 
   let summary = "";
-  if (scheduledUsers.length) {
-    summary += `scheduleForDeactivation: użytkownicy zaplanowani do dezaktywacji (${
-      scheduledUsers.length
-    })\n${scheduledUsers.join("\n")}\n\n`;
-  }
   if (notifiedUsers.length) {
-    summary += `Wysłano powiadomienia (${notifiedUsers.length}):\n`;
+    summary += `Zaplanowano do dezaktywacji i wysłano powiadomienia (${notifiedUsers.length}):\n`;
     summary += notifiedUsers
       .map((u) => `- ${u.email} (Zaplanowano na: ${u.deadline})`)
       .join("\n");

--- a/src/handlers/deactivationHandler.ts
+++ b/src/handlers/deactivationHandler.ts
@@ -89,11 +89,11 @@ export function oldCleanup(): void {
   } while (pageToken);
 
   let summary = "";
+  if (failedUsers.length) {
+    summary += `Błędy podczas przetwarzania:\n${failedUsers.join("\n")}\n\n`;
+  }
   if (deactivatedUsers.length) {
     summary += `Dezaktywowano użytkowników:\n${deactivatedUsers.join("\n")}\n\n`;
-  }
-  if (failedUsers.length) {
-    summary += `Błędy podczas przetwarzania:\n${failedUsers.join("\n")}`;
   }
 
   if (summary) {
@@ -200,13 +200,13 @@ export function scheduleForDeactivation(): void {
   } while (pageToken);
 
   let summary = "";
+  if (failedUsers.length) {
+    summary += `Błędy podczas przetwarzania:\n${failedUsers.join("\n")}\n\n`;
+  }
   if (scheduledUsers.length) {
     summary += `scheduleForDeactivation: użytkownicy zaplanowani do dezaktywacji (${
       scheduledUsers.length
     })\n${scheduledUsers.join("\n")}\n\n`;
-  }
-  if (failedUsers.length) {
-    summary += `Błędy podczas przetwarzania:\n${failedUsers.join("\n")}`;
   }
 
   if (summary) {

--- a/src/handlers/deactivationHandler.ts
+++ b/src/handlers/deactivationHandler.ts
@@ -15,6 +15,7 @@ export function oldCleanup(): void {
   let page: GoogleAppsScript.AdminDirectory.Schema.Users;
   let pageToken: string | undefined;
   const deactivatedUsers: string[] = [];
+  const failedUsers: string[] = [];
 
   do {
     // Get users from NONLEADERS_GROUP
@@ -29,23 +30,24 @@ export function oldCleanup(): void {
     const users = page.users || [];
 
     for (let user of users) {
-      const deadlineString = getRelation(
-        user.relations,
-        "scheduled_for_deactivation"
-      );
+      try {
+        const deadlineString = getRelation(
+          user.relations,
+          "scheduled_for_deactivation"
+        );
 
-      if (deadlineString) {
-        const deadline = new Date(deadlineString);
-        const timeDiff = deadline.getTime() - new Date().getTime();
-        const daysLeft = Math.ceil(timeDiff / MS_PER_DAY);
+        if (deadlineString) {
+          const deadline = new Date(deadlineString);
+          const timeDiff = deadline.getTime() - new Date().getTime();
+          const daysLeft = Math.ceil(timeDiff / MS_PER_DAY);
 
-        // Notify if 14, 7 or 1 days are left
-        if (daysLeft === 14 || daysLeft === 7 || daysLeft === 1) {
-          notifyForDeactivation(user, deadline);
-        }
+          // Notify if 14, 7 or 1 days are left
+          if (daysLeft === 14 || daysLeft === 7 || daysLeft === 1) {
+            notifyForDeactivation(user, deadline);
+            Utilities.sleep(2000); // Wait 2s to avoid hitting rate limits
+          }
 
-        if (timeDiff <= 0) {
-          try {
+          if (timeDiff <= 0) {
             // Suspend and remove scheduled_for_deactivation relation
             const currentRelations = user.relations || [];
             const updatedRelations = currentRelations.filter(
@@ -66,27 +68,39 @@ export function oldCleanup(): void {
               sendEmail(user.recoveryEmail, subject, "", {
                 htmlBody,
               });
+              Utilities.sleep(2000); // Wait 2s to avoid hitting rate limits
             }
             deactivatedUsers.push(user.primaryEmail!);
             console.log(
               `[oldCleanup] User ${user.primaryEmail} has been suspended.`
             );
-          } catch (e) {
-            console.error(
-              `[oldCleanup] Failed to suspend ${user.primaryEmail}: ${e}`
-            );
           }
+        }
+      } catch (e) {
+        console.error(
+          `[oldCleanup] Failed to process user ${user.primaryEmail}: ${e}`
+        );
+        if (user.primaryEmail) {
+          failedUsers.push(`${user.primaryEmail} (${e})`);
         }
       }
     }
     pageToken = page.nextPageToken;
   } while (pageToken);
 
+  let summary = "";
   if (deactivatedUsers.length) {
+    summary += `Dezaktywowano użytkowników:\n${deactivatedUsers.join("\n")}\n\n`;
+  }
+  if (failedUsers.length) {
+    summary += `Błędy podczas przetwarzania:\n${failedUsers.join("\n")}`;
+  }
+
+  if (summary) {
     sendEmail(
       ADMIN_MAIL,
-      "oldCleanup: deaktywacje wykonane",
-      deactivatedUsers.join(" \n")
+      "oldCleanup: raport z wykonania",
+      summary
     );
   }
   console.info("[oldCleanup] Finished deactivation cleanup job");
@@ -119,6 +133,7 @@ export function scheduleForDeactivation(): void {
   let page: GoogleAppsScript.AdminDirectory.Schema.Users;
   let pageToken: string | undefined;
   const scheduledUsers: string[] = [];
+  const failedUsers: string[] = [];
 
   do {
     // Get users from NONLEADERS_GROUP
@@ -158,29 +173,47 @@ export function scheduleForDeactivation(): void {
         continue;
       }
 
-      // Check if account was already scheduled for deactivation
-      const warningRelation = getRelation(
-        user.relations,
-        "scheduled_for_deactivation"
-      );
+      try {
+        // Check if account was already scheduled for deactivation
+        const warningRelation = getRelation(
+          user.relations,
+          "scheduled_for_deactivation"
+        );
 
-      // Schedule only if account wasn't already scheduled for deactivation
-      if (!warningRelation) {
-        const deadline = new Date(now.getTime() + DEACTIVATION_OFFSET_MS);
-        scheduleUserForDeactivation(user, deadline);
-        notifyForDeactivation(user, deadline);
-        scheduledUsers.push(user.primaryEmail);
+        // Schedule only if account wasn't already scheduled for deactivation
+        if (!warningRelation) {
+          const deadline = new Date(now.getTime() + DEACTIVATION_OFFSET_MS);
+          scheduleUserForDeactivation(user, deadline);
+          notifyForDeactivation(user, deadline);
+          Utilities.sleep(2000); // Wait 2s to avoid hitting rate limits
+          scheduledUsers.push(user.primaryEmail);
+        }
+      } catch (e) {
+        console.error(
+          `[scheduleForDeactivation] Failed to process user ${user.primaryEmail}: ${e}`
+        );
+        failedUsers.push(`${user.primaryEmail} (${e})`);
       }
     }
 
     pageToken = page.nextPageToken;
   } while (pageToken);
 
+  let summary = "";
   if (scheduledUsers.length) {
+    summary += `scheduleForDeactivation: użytkownicy zaplanowani do dezaktywacji (${
+      scheduledUsers.length
+    })\n${scheduledUsers.join("\n")}\n\n`;
+  }
+  if (failedUsers.length) {
+    summary += `Błędy podczas przetwarzania:\n${failedUsers.join("\n")}`;
+  }
+
+  if (summary) {
     sendEmail(
       ADMIN_MAIL,
-      `scheduleForDeactivation: użytkownicy zaplanowani do dezaktywacji (${scheduledUsers.length})`,
-      scheduledUsers.join(" \n")
+      `scheduleForDeactivation: raport wykonania`,
+      summary
     );
   }
   console.info("[scheduleForDeactivation] Finished scheduling job");

--- a/src/handlers/httpHandler.ts
+++ b/src/handlers/httpHandler.ts
@@ -1,8 +1,13 @@
 import { getSheet, updateRow } from "../lib/sheet";
 import { getUser, getGoogleUser, getGoogleUserSafe } from "../lib/user";
-import { parseFormUrlEncoded, sendEmail, renderTemplate } from "../lib/utils";
+import {
+  parseFormUrlEncoded,
+  sendEmail,
+  renderTemplate,
+  errorHandler,
+} from "../lib/utils";
 import { verifyToken } from "../lib/auth";
-import { ADMIN_MAIL, MANAGER_MAIL, LEADERS_GROUP } from "../config";
+import { ADMIN_MAIL, LEADERS_GROUP } from "../config";
 
 class OrgUnitPathError extends Error {
   constructor(userEmail: string, orgUnitPath: string) {
@@ -163,21 +168,5 @@ function htmlErrorHandler(
     "superiorError",
     { error: err.message, isOrgUnitPathError },
     title
-  );
-}
-
-function errorHandler(err: Error, func = "unknown", context = undefined) {
-  console.error(`[errorHandler] Error in function '${func}': ${err}`);
-  const msg = `Error message:
-  
-  ${err.stack}
-  
-  Additional data:
-  
-  ${JSON.stringify(context)}`;
-  sendEmail(
-    `${MANAGER_MAIL}, ${ADMIN_MAIL}`,
-    `Error in function '${func}'`,
-    msg
   );
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { ADMIN_MAIL, ADMIN_NAME } from "../config";
+import { ADMIN_MAIL, ADMIN_NAME, MANAGER_MAIL } from "../config";
 
 function sanitize(string: string) {
   return (
@@ -70,4 +70,24 @@ export function renderTemplate(
   layoutTemplate.content = content;
 
   return layoutTemplate.evaluate();
+}
+
+export function errorHandler(
+  err: Error | string,
+  func = "unknown",
+  context: any = undefined
+) {
+  console.error(`[errorHandler] Error in function '${func}': ${err}`);
+  const msg = `Error message:
+
+  ${err instanceof Error ? err.stack : err}
+
+  Additional data:
+
+  ${JSON.stringify(context)}`;
+  sendEmail(
+    `${MANAGER_MAIL}, ${ADMIN_MAIL}`,
+    `Error in function '${func}'`,
+    msg
+  );
 }


### PR DESCRIPTION
Implemented throttling and robust error handling for `oldCleanup` and `scheduleForDeactivation` tasks.

Key changes:
1.  **Rate Limiting:** Added 2-second delays (`Utilities.sleep(2000)`) after sending emails in bulk loops to avoid hitting Google Workspace rate limits.
2.  **Fault Tolerance:** Wrapped the processing of each user in a `try...catch` block. This ensures that if one user fails (e.g., due to a data issue or transient API error), the script logs the error and continues processing the rest of the queue instead of crashing.
3.  **Reporting:** Introduced a `failedUsers` list to collect errors during execution. The final admin summary email now includes a section listing any users who failed to process, alongside the successful deactivations/schedules.

---
*PR created automatically by Jules for task [15418347367190595276](https://jules.google.com/task/15418347367190595276) started by @pniedzwiedzinski*