### PR TITLE
Check if email address is already taken

### DIFF
--- a/src/handlers/editHandler.ts
+++ b/src/handlers/editHandler.ts
@@ -7,17 +7,14 @@ import {
   UNIT_GROUP,
   ADMIN_MAIL,
 } from "../config";
+import { notifySuperior } from "./formHandler";
 
 export function onEdit({
   user,
   value,
   range,
 }: GoogleAppsScript.Events.SheetsOnEdit) {
-  if (value != "Zatwierdzono") {
-    return;
-  }
-
-  console.info("[onEdit] Processing edit event 'Zatwierdzono'");
+  console.info(`[onEdit] Processing edit event, value: ${value}`);
 
   const column = range.getColumn();
   const row = range.getRow();
@@ -29,6 +26,33 @@ export function onEdit({
   if (email != MANAGER_MAIL && email != ADMIN_MAIL) {
     return;
   }
+
+  if (value === "Oczekiwanie na opiekuna") {
+    const sheet = getSheet();
+    const data = getRow(sheet, row);
+    if (data.troupName) {
+      notifySuperior(
+        data.superiorEmail,
+        data.troupName,
+        "",
+        data.primaryEmail
+      );
+    } else {
+      notifySuperior(
+        data.superiorEmail,
+        data.name,
+        data.surname,
+        data.primaryEmail
+      );
+    }
+    return;
+  }
+
+  if (value != "Zatwierdzono") {
+    return;
+  }
+
+  console.info("[onEdit] Processing edit event 'Zatwierdzono'");
 
   const sheet = getSheet();
   const userToCreate = getRow(sheet, row);

--- a/src/handlers/formHandler.ts
+++ b/src/handlers/formHandler.ts
@@ -2,6 +2,7 @@ import { getSheet, getRow, updateRow } from "../lib/sheet";
 import { proposeEmail } from "../lib/utils";
 import { sendEmail, renderTemplate } from "../lib/utils";
 import { PROXY_URL } from "../config";
+import { userExists } from "../lib/user";
 
 /**
  * Handles the event
@@ -10,14 +11,44 @@ export function onFormSubmit(e: GoogleAppsScript.Events.SheetsOnFormSubmit) {
   console.info("[onFormSubmit] Started handling form submission");
   const row = e.range.getRow();
   const sheet = getSheet();
-  let { name, surname, troupName, superiorEmail, primaryEmail } = getRow(
-    sheet,
-    row
-  );
+  let {
+    name,
+    surname,
+    troupName,
+    superiorEmail,
+    primaryEmail,
+    recoveryEmail,
+  } = getRow(sheet, row);
+
+  if (!troupName) {
+    primaryEmail = `${proposeEmail(name, surname)}@zhr.pl`;
+  }
+
+  if (userExists(primaryEmail)) {
+    console.info(
+      `[onFormSubmit] Email ${primaryEmail} is already taken. Rejecting request.`
+    );
+    const subject = `Wybrany adres ${primaryEmail} jest już zajęty`;
+    const htmlBody = renderTemplate(
+      "emailTaken",
+      { mail: primaryEmail },
+      subject
+    ).getContent();
+    sendEmail(recoveryEmail, subject, "", {
+      htmlBody,
+    });
+
+    updateRow(sheet, row, {
+      status: "Odmówiono",
+      primaryEmail,
+      isUnit: !!troupName,
+    });
+    return;
+  }
+
   if (troupName) {
     notifySuperior(superiorEmail, troupName, "", primaryEmail);
   } else {
-    primaryEmail = `${proposeEmail(name, surname)}@zhr.pl`;
     notifySuperior(superiorEmail, name, surname, primaryEmail);
   }
   updateRow(sheet, row, {
@@ -31,7 +62,7 @@ export function onFormSubmit(e: GoogleAppsScript.Events.SheetsOnFormSubmit) {
 /**
  * Send email with superior confirmation link
  */
-function notifySuperior(
+export function notifySuperior(
   superiorEmail: string,
   name: string,
   surname: string,

--- a/src/handlers/formHandler.ts
+++ b/src/handlers/formHandler.ts
@@ -1,7 +1,7 @@
 import { getSheet, getRow, updateRow } from "../lib/sheet";
 import { proposeEmail } from "../lib/utils";
 import { sendEmail, renderTemplate } from "../lib/utils";
-import { PROXY_URL } from "../config";
+import { PROXY_URL, SURVEY_LINK } from "../config";
 import { userExists } from "../lib/user";
 
 /**
@@ -31,7 +31,7 @@ export function onFormSubmit(e: GoogleAppsScript.Events.SheetsOnFormSubmit) {
     const subject = `Wybrany adres ${primaryEmail} jest już zajęty`;
     const htmlBody = renderTemplate(
       "emailTaken",
-      { mail: primaryEmail },
+      { mail: primaryEmail, surveyLink: SURVEY_LINK },
       subject
     ).getContent();
     sendEmail(recoveryEmail, subject, "", {

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -74,17 +74,30 @@ export function getGoogleUserSafe(
   }
 }
 
-function userExists(mail: string) {
+export function userExists(mail: string) {
+  if (!AdminDirectory) {
+    throw new Error("AdminDirectory is undefined");
+  }
+
   try {
-    if (AdminDirectory && AdminDirectory.Users) {
+    if (AdminDirectory.Users) {
       AdminDirectory.Users.get(mail);
-    } else {
-      throw new Error("AdminDirectory.Users is undefined");
+      return true;
     }
   } catch (err) {
-    return false;
+    // User not found, continue to check groups
   }
-  return true;
+
+  try {
+    if (AdminDirectory.Groups) {
+      AdminDirectory.Groups.get(mail);
+      return true;
+    }
+  } catch (err) {
+    // Group not found
+  }
+
+  return false;
 }
 
 export function createUser(

--- a/src/templates/emailTaken.html
+++ b/src/templates/emailTaken.html
@@ -1,6 +1,6 @@
 <div class="header">
   <h1>
-    Wybrany adres
+    Adres
     <a href="mailto:<?= mail ?>"><?= mail ?></a>
     jest już zajęty
   </h1>
@@ -12,11 +12,7 @@
     <strong><?= mail ?></strong> jest już zajęty przez innego użytkownika lub grupę.
   </p>
   <p>
-    Twój wniosek został automatycznie odrzucony. Prosimy o kontakt z administratorem w celu ustalenia unikalnego adresu e-mail.
-    Możesz odpowiedzieć bezpośrednio na tę wiadomość.
-  </p>
-  <p>
-    Po ustaleniu nowego adresu, administrator wprowadzi zmiany i prześle wniosek do ponownej weryfikacji.
+    Twój wniosek został automatycznie odrzucony. Możesz uzupełnić formularz jeszcze raz lub skontaktować się z administratorem z prośbą o nadanie unikalnego adresu e-mail.
   </p>
   <hr />
   <p>

--- a/src/templates/emailTaken.html
+++ b/src/templates/emailTaken.html
@@ -1,0 +1,25 @@
+<div class="header">
+  <h1>
+    Wybrany adres
+    <a href="mailto:<?= mail ?>"><?= mail ?></a>
+    jest już zajęty
+  </h1>
+</div>
+<div class="content">
+  <h2>Czuwaj!</h2>
+  <p>
+    Dziękujemy za przesłanie wniosku o założenie konta w domenie zhr.pl. Niestety wybrany przez Ciebie adres
+    <strong><?= mail ?></strong> jest już zajęty przez innego użytkownika lub grupę.
+  </p>
+  <p>
+    Twój wniosek został automatycznie odrzucony. Prosimy o kontakt z administratorem w celu ustalenia unikalnego adresu e-mail.
+    Możesz odpowiedzieć bezpośrednio na tę wiadomość.
+  </p>
+  <p>
+    Po ustaleniu nowego adresu, administrator wprowadzi zmiany i prześle wniosek do ponownej weryfikacji.
+  </p>
+  <hr />
+  <p>
+    Jeżeli uważasz, że nastąpiła pomyłka, napisz do nas w odpowiedzi na tego maila.
+  </p>
+</div>

--- a/src/templates/emailTaken.html
+++ b/src/templates/emailTaken.html
@@ -14,6 +14,7 @@
   <p>
     Twój wniosek został automatycznie odrzucony. Możesz uzupełnić formularz jeszcze raz lub skontaktować się z administratorem z prośbą o nadanie unikalnego adresu e-mail.
   </p>
+  <a href="<?= surveyLink ?>" class="button">Założenie skrzynki mailowej @zhr</a>
   <hr />
   <p>
     Jeżeli uważasz, że nastąpiła pomyłka, napisz do nas w odpowiedzi na tego maila.


### PR DESCRIPTION
This change implements a check for email availability during new account requests. If a requested email address is already in use by another user or group in the Google Workspace domain, the request is automatically rejected, and the applicant is notified.

Additionally, it updates the `onEdit` handler to support a manual workflow where an administrator can resolve email collisions. After correcting an email address in the spreadsheet, an admin can change the status to 'Oczekiwanie na opiekuna' to trigger the confirmation email to the superior.

Fixes #29

---
*PR created automatically by Jules for task [17692611204635579870](https://jules.google.com/task/17692611204635579870) started by @pniedzwiedzinski*